### PR TITLE
FFD-173 Creates default methods to send queries and mutation with access tokens in header

### DIFF
--- a/frontend/src/src/App.js
+++ b/frontend/src/src/App.js
@@ -2,7 +2,6 @@ import React from "react";
 import "./App.css";
 import Navbar from "./components/Navbar";
 
-
 function App() {
   return (
     <div className="App">

--- a/frontend/src/src/authProvider.js
+++ b/frontend/src/src/authProvider.js
@@ -1,34 +1,37 @@
 // authProvider.js
-import { MsalAuthProvider, LoginType } from 'react-aad-msal';
- 
+import { MsalAuthProvider, LoginType } from "react-aad-msal";
+
 // Msal Configurations
 const config = {
   auth: {
-    clientId: '8a2d7ffd-3754-4913-8277-8ed6a867545f',
-    authority: 'https://login.microsoftonline.com/1ddce0ea-82b3-4340-b681-550781c83ba2/',
-    redirectURI: 'http://localhost:3013'
-},
+    clientId: "8a2d7ffd-3754-4913-8277-8ed6a867545f",
+    authority:
+      "https://login.microsoftonline.com/1ddce0ea-82b3-4340-b681-550781c83ba2/",
+    redirectURI: "http://localhost:3013",
+  },
   cache: {
     cacheLocation: "localStorage",
-    storeAuthStateInCookie: true
-  }
+    storeAuthStateInCookie: true,
+  },
 };
- 
+
 // Authentication Parameters
 const authenticationParameters = {
   scopes: [
-    'api://0ea5e8ad-2ac5-4ea4-bb39-74213a21e4f4/user.read',
-    'api://0ea5e8ad-2ac5-4ea4-bb39-74213a21e4f4/access_as_user'
+    "api://0ea5e8ad-2ac5-4ea4-bb39-74213a21e4f4/user.read",
+    "api://0ea5e8ad-2ac5-4ea4-bb39-74213a21e4f4/access_as_user",
   ],
-  forceRefresh: true
-}
- 
+  forceRefresh: true,
+};
+
 // Options
 const options = {
   loginType: LoginType.Redirect,
-  tokenRefreshUri: window.location.origin + '/auth.html'
-}
- 
-export const authProvider = new MsalAuthProvider(config, authenticationParameters, options)
+  tokenRefreshUri: window.location.origin + "/auth.html",
+};
 
-
+export const authProvider = new MsalAuthProvider(
+  config,
+  authenticationParameters,
+  options
+);

--- a/frontend/src/src/components/AdminPage.js
+++ b/frontend/src/src/components/AdminPage.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React from "react";
 import Navbar from "./Navbar";
 import UploadData from "./UploadData";
 import "./componentStyles/AdminPage.css";

--- a/frontend/src/src/components/QueryBuilder.js
+++ b/frontend/src/src/components/QueryBuilder.js
@@ -5,6 +5,7 @@ import "./componentStyles/QueryBuilder.css";
 import DateTimeRangePicker from "@wojtekmaj/react-datetimerange-picker";
 import { GET_TIME_SERIES, GET_SENSORS } from "../queries/queries";
 import { useApolloClient } from "@apollo/client";
+import sendQuery from "../queries/sendQuery";
 
 function QueryBuilder() {
   /*
@@ -26,11 +27,7 @@ function QueryBuilder() {
     if (measurement.length > 0 && existTrueItem) {
       const input = getQuery();
       // fetch time series and update global state
-      client
-        .query({
-          query: GET_TIME_SERIES,
-          variables: { input },
-        })
+      sendQuery(client, GET_TIME_SERIES, { input })
         .then((result) => dispatch(setQueryData(input, result.data)))
         .catch((err) => console.log(err));
     }
@@ -38,10 +35,7 @@ function QueryBuilder() {
 
   // Fetches data for table and columns when component is loaded
   useEffect(() => {
-    client
-      .query({
-        query: GET_SENSORS,
-      })
+    sendQuery(client, GET_SENSORS, null)
       .then((result) => {
         setSensors(result.data);
         console.log(result.data);

--- a/frontend/src/src/queries/createApolloLink.js
+++ b/frontend/src/src/queries/createApolloLink.js
@@ -1,0 +1,29 @@
+import { createHttpLink } from "@apollo/client";
+import { setContext } from "@apollo/client/link/context";
+import { authProvider } from "../authProvider";
+
+async function createApolloLink() {
+  //Function used by sendQuery and sendMutation
+  //returns the link to be used by the apollo client, with the correct access token
+
+  // Get the logged in user's access token. Either from cache or by requesting it from Azure AD
+  const token = await authProvider.getAccessToken();
+
+  const authLink = setContext((_, { headers }) => {
+    // return the headers to the context so httpLink can read them
+    return {
+      headers: {
+        ...headers,
+        authorization: token ? `Bearer ${token}` : "",
+      },
+    };
+  });
+
+  const httpLink = createHttpLink({
+    uri: "http://api-customerdriven.sanderkk.com/playground/..",
+  });
+
+  return authLink.concat(httpLink);
+}
+
+export default createApolloLink;

--- a/frontend/src/src/queries/sendMutation.js
+++ b/frontend/src/src/queries/sendMutation.js
@@ -1,0 +1,15 @@
+import createApolloLink from "./createApolloLink";
+
+async function sendMutation(client, mutation, variables) {
+  //Function used to send mutations to back end.
+  //Requires client, query and variables as input, is variables is nothing then input null for the variables parameter
+
+  client.setLink(await createApolloLink());
+
+  return await client.mutate({
+    mutation: mutation,
+    variables: variables,
+  });
+}
+
+export default sendMutation;

--- a/frontend/src/src/queries/sendQuery.js
+++ b/frontend/src/src/queries/sendQuery.js
@@ -1,0 +1,15 @@
+import createApolloLink from "./createApolloLink";
+
+async function sendQuery(client, query, variables) {
+  //Function used to send queries to back end.
+  //Requires client, query and variables as input, is variables is nothing then input null for the variables parameter
+
+  client.setLink(await createApolloLink());
+
+  return await client.query({
+    query: query,
+    variables: variables,
+  });
+}
+
+export default sendQuery;


### PR DESCRIPTION
Adds the send query method

Creates default methods to send queries and mutation with access token in header

Removes some unused imports

Removes unused button

#### What does the commit do? 
Adds default methods to send queries and mutation with access tokens in header. Also makes the queryBuilder use the sendQuery method created.

### Checklist
- [X] **Linked** the issue(s)
- [X] **Squashed** my PR into a single commit
- [ ] Added tests to prove that code **works**
- [X] Assigned a **reviewer**
